### PR TITLE
prevent casting to ITxContext to autoclosable as that brings problem …

### DIFF
--- a/automapper/src/main/java/com/valqueries/automapper/TestDoubleTransactionContext.java
+++ b/automapper/src/main/java/com/valqueries/automapper/TestDoubleTransactionContext.java
@@ -38,4 +38,9 @@ public class TestDoubleTransactionContext implements com.valqueries.ITransaction
 	public <T> Optional<T> queryOne(String sql, Setter setter, IRowMapper<T> rowMapper) throws OrmException.MoreThanOneRowFound, NullPointerException {
 		return Optional.empty();
 	}
+
+	@Override
+	public void close() {
+
+	}
 }

--- a/automapper/src/main/java/com/valqueries/automapper/ValqueriesQueryImpl.java
+++ b/automapper/src/main/java/com/valqueries/automapper/ValqueriesQueryImpl.java
@@ -340,7 +340,7 @@ public class ValqueriesQueryImpl<T> extends BaseValqueriesQuery<T> implements Va
 
 	@Override
 	public void close() throws Exception {
-		((AutoCloseable)transactionContext).close();
+		transactionContext.close();
 	}
 
 	private Mapping mapping(Object obj) {

--- a/core/src/main/java/com/valqueries/IOrm.java
+++ b/core/src/main/java/com/valqueries/IOrm.java
@@ -5,7 +5,6 @@
  */
 package com.valqueries;
 
-public interface IOrm extends IOrmOperations, AutoCloseable, ITransactionContext {
-	@Override
-	void close();
+public interface IOrm extends ITransactionContext {
+
 }

--- a/core/src/main/java/com/valqueries/ITransactionContext.java
+++ b/core/src/main/java/com/valqueries/ITransactionContext.java
@@ -5,5 +5,7 @@
  */
 package com.valqueries;
 
-public interface ITransactionContext extends IOrmOperations {
+public interface ITransactionContext extends IOrmOperations, AutoCloseable {
+    @Override
+    void close();
 }


### PR DESCRIPTION
…when testing, if this is going to happen forcefully better to have the close method at this level