### PR TITLE
changed serialized field type to TEXT instead of varchar(4000)

### DIFF
--- a/valqueries-automapper/src/main/java/com/valqueries/automapper/SqlDialect.java
+++ b/valqueries-automapper/src/main/java/com/valqueries/automapper/SqlDialect.java
@@ -77,7 +77,7 @@ public interface SqlDialect {
 			return "DATE";
 		}
 		if (Collection.class.isAssignableFrom(type)) {
-			return "VARCHAR(4000)";
+			return "TEXT";
 		}
 		if (type.isEnum()) {
 			return "VARCHAR(255)";

--- a/valqueries-automapper/src/main/java/com/valqueries/automapper/SqlDialect.java
+++ b/valqueries-automapper/src/main/java/com/valqueries/automapper/SqlDialect.java
@@ -56,7 +56,7 @@ public interface SqlDialect {
 		}
 		Serialized serialized = property.getAnnotations().get(Serialized.class);
 		if (serialized != null) {
-			return "VARCHAR(4000)";
+			return "TEXT";
 		}
 		if (type == String.class) {
 			return "VARCHAR(255)";
@@ -109,9 +109,9 @@ public interface SqlDialect {
 	<O> String getUpsert(CompoundColumnizer<O> columnizer, Class<O> oClass);
 	String getLimitDefinition(int offset, Integer limit);
 	String generateUpdateStatement(TypeDescriber<?> typeDescriber, List<Element> elements, List<Property.PropertyValue> newPropertyValues);
-	
+
 	<O> String getInsert(CompoundColumnizer<O> columnizer, Class<O> oClass);
-	
+
 	default String generateDeleteStatement(String tableAlias, TypeDescriber<?> typeDescriber, List<Element> elements, int offset, Integer limit) {
 		String sql = "DELETE "+tableAlias+" FROM " + getTableName(Clazz.of(typeDescriber.clazz())) + " AS "+tableAlias;
 		if (!elements.isEmpty()) {


### PR DESCRIPTION
This PR fixes an issue where a row can have limits on the number of varchars. See exception below 
```
Caused by: java.sql.SQLException: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
```