### PR TITLE
SAGA-7249:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,17 @@ services:
       #- MSSQL_PID=Express
       - SA_PASSWORD=7h3_s3cr3t!1s?0u7
       - ACCEPT_EULA=Y
+    volumes:
+      - ./valqueries-core/sqlinit/sqlserver/:/scripts
+    command:
+      - /bin/bash
+      - -c
+      - | 
+        /opt/mssql/bin/sqlservr & 
+        for foo in ./scripts/*.sql
+          do /opt/mssql-tools/bin/sqlcmd -U sa -P 7h3_s3cr3t!1s?0u7  -l 30 -e -i /scripts/init.sql
+        done
+        sleep infinity
   sql:
     image: mariadb:10.2.27
     restart: 'no'
@@ -19,7 +30,7 @@ services:
       - mysql_data:/var/lib/mysql
       - mysql_config:/etc/mysql/conf.d
       - mysql_logs:/var/logs/mysql/
-      - ./sqlinit/:/docker-entrypoint-initdb.d
+      - ./valqueries-core/sqlinit/mariadb:/docker-entrypoint-initdb.d/:rw
     environment:
       - MYSQL_ROOT_PASSWORD=s3cr3t
       - MYSQL_ROOT_HOST=%
@@ -30,7 +41,6 @@ services:
         hard: 40000
     healthcheck:
       test: ["CMD", "echo", "'show databases'", "|", "mysql", "-uroot", "-ps3cr3t", "|", "grep", "-q", "information_schema"]
-
 
 volumes:
   mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,7 @@ services:
       - -c
       - | 
         /opt/mssql/bin/sqlservr & 
-        for foo in ./scripts/*.sql
-          do /opt/mssql-tools/bin/sqlcmd -U sa -P 7h3_s3cr3t!1s?0u7  -l 30 -e -i /scripts/init.sql
-        done
+        /opt/mssql-tools/bin/sqlcmd -U sa -P 7h3_s3cr3t!1s?0u7  -l 30 -e -i /scripts/init.sql
         sleep infinity
   sql:
     image: mariadb:10.2.27

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-ran_version=1.3.1-49
+ran_version=1.3.1-53

--- a/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
+++ b/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
@@ -5,6 +5,7 @@ import com.valqueries.IOrm;
 import com.valqueries.UpdateResult;
 import com.valqueries.automapper.DialectFactory;
 import com.valqueries.automapper.SqlDialect;
+import com.valqueries.automapper.SqlNameFormatter;
 import io.ran.schema.SchemaExecutor;
 import io.ran.schema.TableAction;
 
@@ -12,8 +13,8 @@ import javax.inject.Inject;
 import java.util.Collection;
 
 public class ValqueriesSchemaExecutor implements SchemaExecutor {
-	private DialectFactory dialectFactory;
-	private Database database;
+	private final DialectFactory dialectFactory;
+	private final Database database;
 	private String sql = "";
 
 	@Inject
@@ -21,6 +22,11 @@ public class ValqueriesSchemaExecutor implements SchemaExecutor {
 		this.dialectFactory = dialectFactory;
 		this.database = database;
 	}
+
+	public static ValqueriesSchemaExecutor forDatabase(Database database) {
+		return new ValqueriesSchemaExecutor(new DialectFactory(new SqlNameFormatter()), database);
+	}
+
 
 	@Override
 	public void execute(Collection<TableAction> collection) {

--- a/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
+++ b/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
@@ -5,7 +5,6 @@ import com.valqueries.IOrm;
 import com.valqueries.UpdateResult;
 import com.valqueries.automapper.DialectFactory;
 import com.valqueries.automapper.SqlDialect;
-import com.valqueries.automapper.SqlNameFormatter;
 import io.ran.schema.SchemaExecutor;
 import io.ran.schema.TableAction;
 
@@ -23,11 +22,6 @@ public class ValqueriesSchemaExecutor implements SchemaExecutor {
 		this.dialectFactory = dialectFactory;
 		this.database = database;
 	}
-
-	public static ValqueriesSchemaExecutor forDatabase(Database database) {
-		return new ValqueriesSchemaExecutor(new DialectFactory(new SqlNameFormatter()), database);
-	}
-
 
 	@Override
 	public void execute(Collection<TableAction> collection) {

--- a/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
+++ b/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
@@ -36,7 +36,7 @@ public class ValqueriesSchemaExecutor implements SchemaExecutor {
 				for (String a: actions) {
 					if (a.length() > 0) {
 						sql += a+";\n";
-						UpdateResult res = orm.update(a, s -> {	});
+						orm.update(a, s -> {	});
 					}
 				}
 

--- a/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
+++ b/valqueries-automapper/src/main/java/com/valqueries/automapper/schema/ValqueriesSchemaExecutor.java
@@ -10,6 +10,7 @@ import io.ran.schema.SchemaExecutor;
 import io.ran.schema.TableAction;
 
 import javax.inject.Inject;
+import javax.sql.DataSource;
 import java.util.Collection;
 
 public class ValqueriesSchemaExecutor implements SchemaExecutor {
@@ -30,7 +31,11 @@ public class ValqueriesSchemaExecutor implements SchemaExecutor {
 
 	@Override
 	public void execute(Collection<TableAction> collection) {
-		try(IOrm orm = database.getOrm()) {
+		execute(collection, database);
+	}
+
+	private void execute(Collection<TableAction> collection, Database databaseToExecuteOn) {
+		try(IOrm orm = databaseToExecuteOn.getOrm()) {
 			for (TableAction ta : collection) {
 				String action = ta.getAction().apply(ta);
 				String[] actions = action.split(";");
@@ -43,6 +48,11 @@ public class ValqueriesSchemaExecutor implements SchemaExecutor {
 
 			}
 		}
+	}
+
+	@Override
+	public void execute(Collection<TableAction> collection, DataSource datasourceToExecuteOn) {
+		execute(collection, new Database(datasourceToExecuteOn));
 	}
 
 	public SqlDialect getDialect() {

--- a/valqueries-core/sqlinit/mariadb/init.sql
+++ b/valqueries-core/sqlinit/mariadb/init.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE IF NOT EXISTS `mariadbSecondary`;
+GRANT ALL ON `mariadbSecondary` .* TO 'root';

--- a/valqueries-core/sqlinit/sqlserver/init.sql
+++ b/valqueries-core/sqlinit/sqlserver/init.sql
@@ -1,0 +1,6 @@
+IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'sqlServerSecondary')
+    BEGIN;
+        CREATE DATABASE sqlServerSecondary;
+    END;
+GO
+

--- a/valqueries-core/src/main/java/com/valqueries/Database.java
+++ b/valqueries-core/src/main/java/com/valqueries/Database.java
@@ -27,6 +27,10 @@ public class Database {
 		this(dataSource, new DatabaseConfig());
 	}
 
+	public DataSource datasource() {
+		return dataSource;
+	}
+
 	public DialectType getDialectType() {
 		try(Connection connection = dataSource.getConnection()) {
 			String url = connection.getMetaData().getURL();

--- a/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorH2IT.java
+++ b/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorH2IT.java
@@ -1,7 +1,8 @@
 package com.valqueries.automapper;
 
 import com.valqueries.H2DataSourceProvider;
-import com.valqueries.MariaDbDataSourceProvider;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -21,6 +22,19 @@ public class SqlGeneratorH2IT extends SqlGeneratorITBase {
 		return H2DataSourceProvider.get();
 	}
 
+	@Override
+	protected DataSource secondaryDatasource() {
+		HikariConfig config = new HikariConfig();
+
+		config.setJdbcUrl(System.getProperty("db.url", "jdbc:h2:file:/tmp/test2"));
+		config.setDriverClassName("org.h2.Driver");
+		config.setUsername(System.getProperty("db.user", "sa"));
+		config.setPassword(System.getProperty("db.password", "sa"));
+		config.setMinimumIdle(10);
+		config.setMaximumPoolSize(10);
+
+		return new HikariDataSource(config);
+	}
 
 
 }

--- a/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorITBase.java
+++ b/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorITBase.java
@@ -104,8 +104,8 @@ public abstract class SqlGeneratorITBase {
 
 		assertEquals(3, tableThatShouldBeCreated.columns.size());
 		assertNotNull(tableThatShouldBeCreated.columns.get("id"));
-		assertNotNull(tableThatShouldBeCreated.columns.get("title").getType());
-		assertNotNull(tableThatShouldBeCreated.columns.get("created_at").getType());
+		assertNotNull(tableThatShouldBeCreated.columns.get("title"));
+		assertNotNull(tableThatShouldBeCreated.columns.get("created_at"));
 		assertNull(tableThatShouldNotBeCreated);
 	}
 

--- a/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorMariaDbIT.java
+++ b/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorMariaDbIT.java
@@ -1,23 +1,12 @@
 package com.valqueries.automapper;
 
-import com.valqueries.Database;
 import com.valqueries.MariaDbDataSourceProvider;
-import io.ran.TypeDescriberImpl;
-import io.ran.token.Token;
-import org.junit.Before;
-import org.junit.Test;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.sql.DataSource;
-
-import java.util.Collections;
-
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SqlGeneratorMariaDbIT extends SqlGeneratorITBase {
@@ -34,5 +23,18 @@ public class SqlGeneratorMariaDbIT extends SqlGeneratorITBase {
 	}
 
 
+	@Override
+	protected DataSource secondaryDatasource() {
+		HikariConfig config = new HikariConfig();
+
+		config.setJdbcUrl(System.getProperty("db.url", "jdbc:mariadb://localhost:3307/valqueriesSecondary"));
+		config.setDriverClassName("org.mariadb.jdbc.Driver");
+		config.setUsername(System.getProperty("db.user", "root"));
+		config.setPassword(System.getProperty("db.password", "s3cr3t"));
+		config.setMinimumIdle(10);
+		config.setMaximumPoolSize(10);
+
+		return new HikariDataSource(config);
+	}
 
 }

--- a/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorMariaDbIT.java
+++ b/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorMariaDbIT.java
@@ -27,7 +27,7 @@ public class SqlGeneratorMariaDbIT extends SqlGeneratorITBase {
 	protected DataSource secondaryDatasource() {
 		HikariConfig config = new HikariConfig();
 
-		config.setJdbcUrl(System.getProperty("db.url", "jdbc:mariadb://localhost:3307/valqueriesSecondary"));
+		config.setJdbcUrl(System.getProperty("db.url", "jdbc:mariadb://localhost:3307/mariadbSecondary"));
 		config.setDriverClassName("org.mariadb.jdbc.Driver");
 		config.setUsername(System.getProperty("db.user", "root"));
 		config.setPassword(System.getProperty("db.password", "s3cr3t"));

--- a/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorSqlServerIT.java
+++ b/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorSqlServerIT.java
@@ -1,16 +1,12 @@
 package com.valqueries.automapper;
 
-import com.valqueries.MariaDbDataSourceProvider;
 import com.valqueries.SqlServerDataSourceProvider;
-import io.ran.TypeDescriberImpl;
-import org.junit.Test;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.sql.DataSource;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SqlGeneratorSqlServerIT extends SqlGeneratorITBase {
@@ -25,4 +21,19 @@ public class SqlGeneratorSqlServerIT extends SqlGeneratorITBase {
 	protected DataSource getDataSource() {
 		return SqlServerDataSourceProvider.get();
 	}
+
+	@Override
+	protected DataSource secondaryDatasource() {
+		HikariConfig config = new HikariConfig();
+
+		config.setJdbcUrl(System.getProperty("db.url", "jdbc:sqlserver://localhostSecondary"));
+		config.setDriverClassName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+		config.setUsername(System.getProperty("db.user", "sa"));
+		config.setPassword(System.getProperty("db.password", "7h3_s3cr3t!1s?0u7"));
+		config.setMinimumIdle(10);
+		config.setMaximumPoolSize(10);
+
+		return new HikariDataSource(config);
+	}
+
 }

--- a/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorSqlServerIT.java
+++ b/valqueries-test/src/test/java/com/valqueries/automapper/SqlGeneratorSqlServerIT.java
@@ -26,7 +26,7 @@ public class SqlGeneratorSqlServerIT extends SqlGeneratorITBase {
 	protected DataSource secondaryDatasource() {
 		HikariConfig config = new HikariConfig();
 
-		config.setJdbcUrl(System.getProperty("db.url", "jdbc:sqlserver://localhostSecondary"));
+		config.setJdbcUrl(System.getProperty("db.url", "jdbc:sqlserver://localhost;database=sqlServerSecondary"));
 		config.setDriverClassName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
 		config.setUsername(System.getProperty("db.user", "sa"));
 		config.setPassword(System.getProperty("db.password", "7h3_s3cr3t!1s?0u7"));


### PR DESCRIPTION
SqlGenerator always runs the code it generates via its schemaBuilder. The injected schemaBuilder does not have a way to use a different database (it defaults to the one originally injected). This pr is an attempt to solve this issue. 

[Jira](https://persequor.atlassian.net/jira/software/c/projects/SAGA/boards/25?modal=detail&selectedIssue=SAGA-7249)
